### PR TITLE
Migrate to fasteval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 [dependencies]
 failure = "0.1"
 indextree = "3.0"
-meval = "0.2"
+fasteval = "0.2"
+regex = "1.3"
 roxmltree = "0.3"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
-extern crate failure;
-extern crate indextree;
 #[cfg(test)]
 #[macro_use]
 extern crate matches;
-extern crate meval;
-extern crate roxmltree;
 
 pub use runner::{AppRunner, Runner, RunnerData, State};
 pub use tree::BulletML;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,4 @@
 use indextree::{Arena, NodeId};
-use meval::Expr;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -17,7 +16,7 @@ pub enum BulletMLNode {
 
     Accel,
 
-    Wait(Expr),
+    Wait(fasteval::ExpressionI),
 
     Vanish,
 
@@ -25,32 +24,32 @@ pub enum BulletMLNode {
 
     Direction {
         dir_type: Option<DirectionType>,
-        dir: Expr,
+        dir: fasteval::ExpressionI,
     },
 
     Speed {
         spd_type: Option<SpeedType>,
-        spd: Expr,
+        spd: fasteval::ExpressionI,
     },
 
     Horizontal {
         h_type: HVType,
-        h: Expr,
+        h: fasteval::ExpressionI,
     },
     Vertical {
         v_type: HVType,
-        v: Expr,
+        v: fasteval::ExpressionI,
     },
 
-    Term(Expr),
+    Term(fasteval::ExpressionI),
 
-    Times(Expr),
+    Times(fasteval::ExpressionI),
 
     BulletRef(String),
     ActionRef(String),
     FireRef(String),
 
-    Param(Expr),
+    Param(fasteval::ExpressionI),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -170,4 +169,5 @@ pub struct BulletML {
     pub bullet_refs: HashMap<String, NodeId>,
     pub action_refs: HashMap<String, NodeId>,
     pub fire_refs: HashMap<String, NodeId>,
+    pub expr_slab: fasteval::Slab,
 }


### PR DESCRIPTION
This prevents unnecessary allocations and RefCell hacks during
execution.